### PR TITLE
Fix deprecations

### DIFF
--- a/db.js
+++ b/db.js
@@ -6,7 +6,10 @@ var Values = mongoose.model('values', schema);
 
 module.exports = {
     connectDB : function() {
-        mongoose.connect(process.env.MONGODB_ADDON_URI, { useNewUrlParser: true });
+        mongoose.connect(process.env.MONGODB_ADDON_URI, {
+          useNewUrlParser: true,
+          useUnifiedTopology: true,
+        });
     },
 
     updateGauge : function() {

--- a/db.js
+++ b/db.js
@@ -13,7 +13,7 @@ module.exports = {
     },
 
     updateGauge : function() {
-        Values.count(function(err, result) {
+        Values.countDocuments(function(err, result) {
             if(!err) {
                 statsd.gauge('values', result);
             }
@@ -52,7 +52,7 @@ module.exports = {
     },
 
     delVal : function(id) {
-        Values.remove({_id: id}, (err) => {
+        Values.deleteOne({_id: id}, (err) => {
             if (err) {
                 console.log(err);
             }


### PR DESCRIPTION
### We were getting a deprecation warning on connecting to Mongoose

`(node:17966) DeprecationWarning: current Server Discovery and Monitoring engine is deprecated, and will be removed in a future version. To use the new Server Discover and Monitoring engine, pass option { useUnifiedTopology: true } to the MongoClient constructor.`



### We were also getting deprecation warnings on functions used on Mongoose Models

`(node:20379) DeprecationWarning: collection.count is deprecated, and will be removed in a future version. Use Collection.countDocuments or Collection.estimatedDocumentCount instead`

`(node:20379) DeprecationWarning: collection.remove is deprecated. Use deleteOne, deleteMany, or bulkWrite instead.
`

Adding these updates should prevent failures in the future.
